### PR TITLE
Prune unused requirements from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-awscli==1.11.82
 bcrypt==3.1.3
-elasticsearch==5.3.0
 SQLAlchemy==1.2.1
-sqlparse==0.2.3
 tornado==4.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bcrypt==3.1.3
 SQLAlchemy==1.2.1
 tornado==4.5.3
+jwt==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bcrypt==3.1.3
 SQLAlchemy==1.2.1
 tornado==4.5.3
-jwt==0.5.2
+pyjwt==1.6.1


### PR DESCRIPTION
These three libraries (awscli, elasticsearch, and sqlparse) don't seem to be used in the server code. bcrypt could also be removed based on the suggestion in #1.