### PR TITLE
Ignore bundle.js build product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # sqlite db file
 *.db
 
+# Built frontend bundle.
+bundle.js
+
 # MySQL Schema file
 *.mwb
 


### PR DESCRIPTION
It's generally frowned upon to keep build products (i.e., the result of compilation) checked into your git repository. This makes for noisier diffs, for example, and makes it possible to get into confusing situations where the source files get "out of sync" with the compiled products. The bundled JavaScript output is one such example.

This commit removes `bundle.js` from the repository and adds it to your `.gitignore`. If this is merged, it would also be a good idea to add instructions to README about how to recreate it (e.g., `npm install` or something followed by `npm run webpack` or similar).