### PR TITLE
Remove unused dependency on bcrypt library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bcrypt==3.1.3
 SQLAlchemy==1.2.1
 tornado==4.5.3
 pyjwt==1.6.1

--- a/zocalo/service/user_service.py
+++ b/zocalo/service/user_service.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import bcrypt
 import hashlib, binascii
 from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import sessionmaker
@@ -31,7 +30,6 @@ class UserService:
             pass
 
         try:
-            # if not bcrypt.checkpw(data["password"], user.password):
             print(user.password)
             print(self.hash_password(data["password"]))
             if user.password != self.hash_password(data["password"]):


### PR DESCRIPTION
Now that password hashing uses Python 3's built-in PBKDF2 algorithm, the `bcrypt` module from PyPI is no longer necessary.